### PR TITLE
Make GlideRecord a generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,43 @@ Currently there are three type packages available `server`,`client`,and `util`.
 
 This contains the server-side types for ServiceNow's backend such as `GlideRecord`, `GlideAggregate` and so on.
 
+#### GlideRecord as a generic type
+
+GlideRecord has been converted to a generic type, that means that you can get some really rich type completions by creating types for your tables!
+
+```typescript
+import { GlideRecord, GlideElement } from '@nuvolo/servicenow-types';
+import { ReferenceGlideElement } from '@nuvolo/servicenow-types/util';
+
+interface MyTableOne {
+  field_one: GlideElement;
+  field_two: ReferenceGlideElement<MyTableTwo>;
+}
+
+interface MyTableTwo {
+  field_three: GlideElement;
+}
+
+// Set up a GlideRecord for my_table_one and pass the type for that table
+const myTableGR = new GlideRecord<MyTableOne>('my_table_one');
+/**
+ * Methods like addQuery will:
+ * 1. Suggest fields from the table
+ * 2. Prevent using fields that aren't on the table
+ * 3. Suggest operators
+ */
+myTableGR.addQuery('field_one', '=', 'asdf');
+myTableGR.query();
+/**
+ * The Gliderecord will:
+ * 1. Expose field properties as type GlideElement or ReferenceGlideElement,
+ *    which makes you use getValue/setValue.
+ * 2. Correctly resolve getRefRecord on ReferenceGlideElements
+ *    (tableTwoGR is now a GlideRecord for MyTableTwo)
+ */
+const tableTwoGR = myTableGR.field_two.getRefRecord();
+```
+
 ### Client
 
 This contains client-side types for ServiceNow such as `GlideAjax`.
@@ -23,22 +60,6 @@ This contains client-side types for ServiceNow such as `GlideAjax`.
 ### Util
 
 This package is for convenience types.
-
-#### TypedGR
-
-`TypedGR` is a utility type for creating more useful GlideRecord interactions. It can be combined with `ReferenceGlideElement` to make `getRefRecord()` work really well. It is a generic, which means you can create interfaces for your table structures and get type inferences for them.
-
-```typescript
-import { GlideRecord, GlideElement } from "@nuvolo/servicenow-types/server";
-import { TypedGR } from "@nuvolo/servicenow-types/util";
-//interface for my_table. All properties are GlideElements
-interface my_table {
-  test: GlideElement;
-  test2: GlideElement;
-}
-//gr will now suggest test and test2 as properties
-let gr = new GlideRecord("my_table") as TypedGR<my_table>;
-```
 
 #### ReferenceGlideElement
 

--- a/client/SNAPIGlideForm.d.ts
+++ b/client/SNAPIGlideForm.d.ts
@@ -34,7 +34,7 @@ declare class SNAPIGlideForm {
     fieldName: string,
     icon: string,
     title: string,
-    color: string
+    color: string,
   ): void;
   /**
    * Displays the error message at the top of the form.
@@ -64,7 +64,7 @@ declare class SNAPIGlideForm {
     fieldName: string,
     choiceValue: string,
     choiceLabel: string,
-    choiceIndex: number
+    choiceIndex: number,
   ): void;
   /**
    * Removes all informational and error messages from the top of the form.
@@ -259,7 +259,7 @@ declare class SNAPIGlideForm {
     fieldName: string,
     icon: string,
     title: string,
-    color: string
+    color: string,
   ): void;
   /**
    * Removes the specified option from the choice list.
@@ -375,7 +375,7 @@ declare class SNAPIGlideForm {
     field: string,
     message: string,
     type: string,
-    scrollForm: boolean
+    scrollForm: boolean,
   ): void;
   /**
    * Displays the specified related list on the form.

--- a/server/GlideFilter.d.ts
+++ b/server/GlideFilter.d.ts
@@ -18,6 +18,10 @@ declare class GlideFilter extends SNAPIGlideFilter {
    *
    * Default: true
    */
-  static checkRecord(gr: GlideRecord, filter: string, match?: boolean): boolean;
+  static checkRecord(
+    gr: GlideRecord<any>,
+    filter: string,
+    match?: boolean,
+  ): boolean;
 }
 export { GlideFilter };

--- a/server/GlideRecord.d.ts
+++ b/server/GlideRecord.d.ts
@@ -1,6 +1,7 @@
 import { SNAPIGlideRecord } from './SNAPIGlideRecord';
 import { GlideQueryCondition } from './GlideQueryCondition';
 import { GlideElement } from './GlideElement';
+import { QueryOperator } from '../util';
 type FieldType<T> = Extract<keyof T, string>;
 declare class GlideRecordBase<T> extends SNAPIGlideRecord {
   /**
@@ -32,7 +33,7 @@ declare class GlideRecordBase<T> extends SNAPIGlideRecord {
   addQuery(fieldName: FieldType<T>, value: any): GlideQueryCondition;
   addQuery(
     name: FieldType<T>,
-    operator: string,
+    operator: QueryOperator,
     value: any,
   ): GlideQueryCondition;
   /**

--- a/server/GlideRecord.d.ts
+++ b/server/GlideRecord.d.ts
@@ -1,5 +1,40 @@
 import { SNAPIGlideRecord } from './SNAPIGlideRecord';
-declare class GlideRecord extends SNAPIGlideRecord {
+import { GlideQueryCondition } from './GlideQueryCondition';
+import { GlideElement } from './GlideElement';
+type FieldType<T> = Extract<keyof T, string>;
+declare class GlideRecordBase<T> extends SNAPIGlideRecord {
+  /**
+   * Adds a filter to return records based on a relationship in a related table.
+   * @param joinTable Table name
+   * @param primaryField (Optional) If other than sys_id, the primary field
+   * @param joinTableField (Optional) If other than sys_id, the field that joins the tables.
+   */
+  addJoinQuery(
+    joinTable: string,
+    primaryField?: FieldType<T>,
+    joinTableField?: any,
+  ): GlideQueryCondition;
+
+  /**
+   * A filter that specifies records where the value of the field passed in the parameter is
+   * not null.
+   * @param fieldName Name of the field to check.
+   */
+  addNotNullQuery(fieldName: FieldType<T>): GlideQueryCondition;
+
+  /**
+   * Provides the ability to build a request, which when executed, returns the rows from the
+   * specified table, that match the request.
+   * @param fieldName Table field name.
+   * @param value Value on which to query (not case-sensitive).
+   */
+  addQuery(): GlideQueryCondition;
+  addQuery(fieldName: FieldType<T>, value: any): GlideQueryCondition;
+  addQuery(
+    name: FieldType<T>,
+    operator: string,
+    value: any,
+  ): GlideQueryCondition;
   /**
    * Returns the specified record in an instantiated GlideRecord object.
    * @param sys_id sys_id of the record to get.
@@ -12,7 +47,44 @@ declare class GlideRecord extends SNAPIGlideRecord {
    * passed in, the method assumes that this parameter is sys_id.
    * @param value Value to match.
    */
-  get(fieldName: string, value: string): boolean;
+  get(fieldName: FieldType<T>, value: string): boolean;
+
+  /**
+   * Returns the dictionary attributes for the specified field.
+   * @param fieldName Field name for which to return the dictionary attributes
+   */
+  getAttribute(fieldName: FieldType<T>): string;
+
+  /**
+   * Retrieves the GlideElement object for the specified field.
+   * @param fieldName Name of the column to get the element from.
+   */
+  getElement(fieldName: FieldType<T>): GlideElement;
+
+  /**
+   * Retrieves the string value of an underlying element in a field.
+   * @param fieldName The name of the field to get the value from.
+   */
+  getValue(fieldName: FieldType<T>): string;
+
+  /**
+   * Specifies an orderBy column.
+   * @param fieldName The column name used to order the records in this GlideRecord object.
+   */
+  orderBy(fieldName: FieldType<T>): void;
+
+  /**
+   * Specifies a decending orderBy column.
+   * @param fieldName The column name to be used to order the records in a GlideRecord object.
+   */
+  orderByDesc(fieldName: FieldType<T>): void;
+
+  /**
+   * Sets the value of the field with the specified name to the specified value.
+   * @param fieldName Name of the field.
+   * @param value The value to assign to the field.
+   */
+  setValue(fieldName: FieldType<T>, value: any): void;
   /**
    * Runs the query against the table based on the filters specified by addQuery,
    * addEncodedQuery, etc.
@@ -20,7 +92,7 @@ declare class GlideRecord extends SNAPIGlideRecord {
    * @param value Value to query for.
    */
   query(): void;
-  query(name: any, value: any): void;
+  query(name: FieldType<T>, value: any): void;
   /**
    * Identical to query(). This method is intended to be used on tables
    * where there is a column named query, which would interfere with using the
@@ -31,4 +103,8 @@ declare class GlideRecord extends SNAPIGlideRecord {
   _query(): void;
   _query(name: any, value: any): void;
 }
+
+type GlideRecordConstructor = { new <T>(table: string): GlideRecord<T> };
+type GlideRecord<T> = GlideRecordBase<T> & T;
+declare const GlideRecord: GlideRecordConstructor;
 export { GlideRecord };

--- a/server/SNAPIGlideElement.d.ts
+++ b/server/SNAPIGlideElement.d.ts
@@ -102,7 +102,7 @@ declare class SNAPIGlideElement {
   /**
    * Returns a GlideRecord object for a given reference element.
    */
-  getRefRecord(): GlideRecord;
+  getRefRecord(): GlideRecord<any>;
   /**
    * Returns the name of the table on which the field resides.
    */

--- a/server/SNAPIGlideFilter.d.ts
+++ b/server/SNAPIGlideFilter.d.ts
@@ -16,6 +16,6 @@ declare class SNAPIGlideFilter {
    *
    * Default: true
    */
-  checkRecord(gr: GlideRecord, filter: string, match?: boolean): boolean;
+  checkRecord(gr: GlideRecord<any>, filter: string, match?: boolean): boolean;
 }
 export { SNAPIGlideFilter };

--- a/server/SNAPIGlideSPScriptable.d.ts
+++ b/server/SNAPIGlideSPScriptable.d.ts
@@ -4,7 +4,7 @@ declare class SNAPIGlideSPScriptable {
    * Returns true if the user can read the specified GlideRecord.
    * @param gr The GlideRecord to check.
    */
-  canReadRecord(gr: GlideRecord): boolean;
+  canReadRecord(gr: GlideRecord<any>): boolean;
   /**
    * Returns true if the user can read the specified GlideRecord.
    * @param table Name of the table to query.
@@ -49,21 +49,21 @@ declare class SNAPIGlideSPScriptable {
    * @param gr The GlideRecord to check
    * @param fieldName The field to find information for
    */
-  getField(gr: GlideRecord, fieldName: string): any;
+  getField(gr: GlideRecord<any>, fieldName: string): any;
   /**
    * Checks the specified list of field names, and returns an array of valid field
    * names.
    * @param gr The GlideRecord to check
    * @param field_Names A comma separated list of field names.
    */
-  getFields(gr: GlideRecord, field_Names: string): any[];
+  getFields(gr: GlideRecord<any>, field_Names: string): any[];
   /**
    * Checks the specified list of field names and returns an object of valid field
    * names.
    * @param gr The GlideRecord to check
    * @param field_Names A comma separated list of field names.
    */
-  getFieldsObject(gr: GlideRecord, field_Names: string): any;
+  getFieldsObject(gr: GlideRecord<any>, field_Names: string): any;
   /**
    * Return the form.
    * @param tableName The name of the table
@@ -87,7 +87,7 @@ declare class SNAPIGlideSPScriptable {
   getKBCategoryArticleSummaries(
     sys_id: string,
     limit: number,
-    maxChars: number
+    maxChars: number,
   ): any[];
   /**
    * Returns the number of articles in the defined Knowledge Base.
@@ -104,7 +104,7 @@ declare class SNAPIGlideSPScriptable {
    * Returns the (?id=) portion of the URL based on the sp_menu type.
    * @param page The page
    */
-  getMenuHREF(page: GlideRecord): string;
+  getMenuHREF(page: GlideRecord<any>): string;
   /**
    * Returns an array of menu items for the specified instance.
    * @param sysId sysId of the instance
@@ -118,7 +118,7 @@ declare class SNAPIGlideSPScriptable {
   /**
    * Returns the portal GlideRecord from the Service Portals [sp_portal] table.
    */
-  getPortalRecord(): GlideRecord;
+  getPortalRecord(): GlideRecord<any>;
   /**
    * If parameters are provided, returns the GlideRecord identified by the provided table
    * and Sys ID. If no parameters are provided, returns the record identified by the current URL.
@@ -127,14 +127,18 @@ declare class SNAPIGlideSPScriptable {
    * @param sys_id Optional. The Sys ID of the record to return. If no parameters are included,
    * returns the record identified by the current URL.
    */
-  getRecord(table?: string, sys_id?: string): GlideRecord;
+  getRecord(table?: string, sys_id?: string): GlideRecord<any>;
   /**
    * Copies display values for the specified fields into the data parameter.
    * @param data The display values for the specified fields are copied to this object.
    * @param from The GlideRecord to process.
    * @param names A comma-separated list of field names.
    */
-  getRecordDisplayValues(data: any, from: GlideRecord, names: string): void;
+  getRecordDisplayValues(
+    data: any,
+    from: GlideRecord<any>,
+    names: string,
+  ): void;
   /**
    * For the specified fields, copies the element's name, display value, and value into the
    * data parameter.
@@ -143,7 +147,7 @@ declare class SNAPIGlideSPScriptable {
    * @param from The GlideRecord to process.
    * @param names A comma-separated list of field names.
    */
-  getRecordElements(data: any, from: GlideRecord, names: string): void;
+  getRecordElements(data: any, from: GlideRecord<any>, names: string): void;
   /**
    * Copies values for the specified field names from the GlideRecord into the data
    * parameter.
@@ -151,7 +155,7 @@ declare class SNAPIGlideSPScriptable {
    * @param from The GlideRecord to process.
    * @param names A comma-separated list of field names.
    */
-  getRecordValues(data: any, from: GlideRecord, names: string): void;
+  getRecordValues(data: any, from: GlideRecord<any>, names: string): void;
   /**
    * Returns Service Catalog
    * variables associated with a record in String format.
@@ -161,7 +165,10 @@ declare class SNAPIGlideSPScriptable {
    * through a record producer.
    * @param includeNilResponses Optional. If true, the API includes variables with no user-defined value.
    */
-  getRecordVariables(gr: GlideRecord, includeNilResponses?: boolean): string;
+  getRecordVariables(
+    gr: GlideRecord<any>,
+    includeNilResponses?: boolean,
+  ): string;
   /**
    * Returns an array of Service Catalog variables associated
    * with a record.
@@ -171,7 +178,10 @@ declare class SNAPIGlideSPScriptable {
    * through a record producer.
    * @param includeNilResponses Optional. If true, the API includes variables with no user-defined value.
    */
-  getRecordVariablesArray(gr: GlideRecord, includeNilResponses?: boolean): any;
+  getRecordVariablesArray(
+    gr: GlideRecord<any>,
+    includeNilResponses?: boolean,
+  ): any;
   /**
    * Gets the activity stream for the specified record. This method works on tables that
    * extend the task table.

--- a/server/SNAPIGlideScopedEvaluator.d.ts
+++ b/server/SNAPIGlideScopedEvaluator.d.ts
@@ -9,7 +9,7 @@ declare class SNAPIGlideScopedEvaluator {
    * available to the script during execution of this method.
    */
   evaluateScript(
-    grObj: GlideRecord,
+    grObj: GlideRecord<any>,
     scriptField?: string,
     variables?: any
   ): any;

--- a/server/SNAPIGlideSysAttachment.d.ts
+++ b/server/SNAPIGlideSysAttachment.d.ts
@@ -13,7 +13,7 @@ declare class SNAPIGlideSysAttachment {
     sourceTable: string,
     sourceID: string,
     targetTable: string,
-    targetID: string
+    targetID: string,
   ): string;
   /**
    * Deletes the specified attachment.
@@ -24,12 +24,12 @@ declare class SNAPIGlideSysAttachment {
    * Returns the attachment content as a string.
    * @param sysAttachment The attachment record.
    */
-  getContent(sysAttachment: GlideRecord): string;
+  getContent(sysAttachment: GlideRecord<any>): string;
   /**
    * Returns the attachment content as a string with base64 encoding.
    * @param sysAttachment The attachment record.
    */
-  getContentBase64(sysAttachment: GlideRecord): string;
+  getContentBase64(sysAttachment: GlideRecord<any>): string;
   /**
    * Returns a GlideScriptableInputStream object given the sysID of an
    * attachment.
@@ -44,10 +44,10 @@ declare class SNAPIGlideSysAttachment {
    * @param content The attachment content.
    */
   write(
-    record: GlideRecord,
+    record: GlideRecord<any>,
     fileName: string,
     contentType: string,
-    content: string
+    content: string,
   ): string;
   /**
    * Inserts an attachment for the specified record using base64 encoded
@@ -58,10 +58,10 @@ declare class SNAPIGlideSysAttachment {
    * @param content The attachment content in base64 format.
    */
   writeBase64(
-    gr: GlideRecord,
+    gr: GlideRecord<any>,
     fileName: string,
     contentType: string,
-    content: string
+    content: string,
   ): string;
   /**
    * Inserts an attachment using the input stream.
@@ -71,10 +71,10 @@ declare class SNAPIGlideSysAttachment {
    * @param content The attachment content.
    */
   writeContentStream(
-    gr: GlideRecord,
+    gr: GlideRecord<any>,
     fileName: string,
     contentType: string,
-    content: GlideScriptableInputStream
+    content: GlideScriptableInputStream,
   ): string;
 }
 export { SNAPIGlideSysAttachment };

--- a/server/SNAPIGlideSystem.d.ts
+++ b/server/SNAPIGlideSystem.d.ts
@@ -96,7 +96,7 @@ declare class SNAPIGlideSystem {
     param2?: any,
     param3?: any,
     param4?: any,
-    param5?: any
+    param5?: any,
   ): void;
   /**
    * Returns the date and time for the end of last month in GMT.
@@ -153,7 +153,7 @@ declare class SNAPIGlideSystem {
     param2?: any,
     param3?: any,
     param4?: any,
-    param5?: any
+    param5?: any,
   ): void;
   /**
    * Queues an event for the event manager.
@@ -168,7 +168,7 @@ declare class SNAPIGlideSystem {
     instance: any,
     parm1?: string,
     parm2?: string,
-    queue?: string
+    queue?: string,
   ): void;
   /**
    * Queues an event for the event manager at a specified date and time.
@@ -183,13 +183,13 @@ declare class SNAPIGlideSystem {
     instance: any,
     parm1: string | undefined,
     parm2: string | undefined,
-    expiration: any
+    expiration: any,
   ): void;
   /**
    * Executes a job for a scoped application.
    * @param job The job to be run.
    */
-  executeNow(job: GlideRecord): string;
+  executeNow(job: GlideRecord<any>): string;
   /**
    * Generates a GUID that can be used when a unique identifier is required.
    */
@@ -319,7 +319,7 @@ declare class SNAPIGlideSystem {
     param2?: any,
     param3?: any,
     param4?: any,
-    param5?: any
+    param5?: any,
   ): void;
   /**
    * Determines if debugging is active for a specific scope.
@@ -425,7 +425,7 @@ declare class SNAPIGlideSystem {
     param2?: any,
     param3?: any,
     param4?: any,
-    param5?: any
+    param5?: any,
   ): void;
   /**
    * Takes an XML string and returns a JSON object.

--- a/server/sn_clotho/sn_clotho_SNAPIClient.d.ts
+++ b/server/sn_clotho/sn_clotho_SNAPIClient.d.ts
@@ -9,7 +9,7 @@ declare class sn_clotho_SNAPIClient {
    * deleted.
    * @param metric The name of the metric.
    */
-  deleteSeries(gr: GlideRecord, metric: string): void;
+  deleteSeries(gr: GlideRecord<any>, metric: string): void;
   /**
    * Save metric data to the MetricBase database.
    * @param metricData A DataBuilder object containing metric data.

--- a/server/sn_clotho/sn_clotho_SNAPITransformer.d.ts
+++ b/server/sn_clotho/sn_clotho_SNAPITransformer.d.ts
@@ -3,7 +3,7 @@ import { GlideDateTime } from '../GlideDateTime';
 import { TransformResult } from '../sn_clotho';
 import { TransformPart } from '../sn_clotho';
 declare class sn_clotho_SNAPITransformer {
-  constructor(sourceRecords: GlideRecord);
+  constructor(sourceRecords: GlideRecord<any>);
   /**
    * Run the transform.
    * @param start The beginning of the period to be evaluated.

--- a/server/sn_cmdb/sn_cmdb_SNAPIIdentificationEngine.d.ts
+++ b/server/sn_cmdb/sn_cmdb_SNAPIIdentificationEngine.d.ts
@@ -69,6 +69,6 @@ declare class sn_cmdb_SNAPIIdentificationEngine {
    * @param gr The CI on which to run the audit to detect duplicates. The CI must have
    * independent identification rules.
    */
-  runIdentificationAudit(gr: GlideRecord): void;
+  runIdentificationAudit(gr: GlideRecord<any>): void;
 }
 export { sn_cmdb_SNAPIIdentificationEngine };

--- a/server/sn_hw/sn_hw_SNAPIHistoryWalker.d.ts
+++ b/server/sn_hw/sn_hw_SNAPIHistoryWalker.d.ts
@@ -10,12 +10,12 @@ declare class sn_hw_SNAPIHistoryWalker {
    * Gets the record filled with the history/audit data after walking to an update
    * number.
    */
-  getWalkedRecord(): GlideRecord;
+  getWalkedRecord(): GlideRecord<any>;
   /**
    * Gets a copy of the record filled with the history/audit data after walking to an update
    * number.
    */
-  getWalkedRecordCopy(): GlideRecord;
+  getWalkedRecordCopy(): GlideRecord<any>;
   /**
    * Specifies if the record-level read access is applied on the record when retrieving from
    * the database.

--- a/server/sn_interaction/sn_interaction_SNAPIInteraction.d.ts
+++ b/server/sn_interaction/sn_interaction_SNAPIInteraction.d.ts
@@ -17,7 +17,7 @@ declare class sn_interaction_SNAPIInteraction {
    * @param interaction Interaction record from the interaction table [interaction] that is retrieved
    * from the system.
    */
-  getInteraction(interaction: GlideRecord): any;
+  getInteraction(interaction: GlideRecord<any>): any;
   /**
    * Transfer an interaction record to an agent using the sys_id for the agent.
    * @param SysID The sys_id of the user you want to transfer an interaction record to.

--- a/server/sn_interaction/sn_interaction_SNAPIInteractionQueue.d.ts
+++ b/server/sn_interaction/sn_interaction_SNAPIInteractionQueue.d.ts
@@ -8,7 +8,7 @@ declare class sn_interaction_SNAPIInteractionQueue {
    * Get an existing interaction queue by sys_id.
    * @param queue Queue from the interaction_queue table.
    */
-  get(queue: GlideRecord): any;
+  get(queue: GlideRecord<any>): any;
   /**
    * Returns a list of agents who are online and assigned to a particular queue.
    */
@@ -17,7 +17,7 @@ declare class sn_interaction_SNAPIInteractionQueue {
    * Check if a user is an agent for a queue.
    * @param queue Sys ID for a queue in the interaction_queue table.
    */
-  isAgentFor(queue: GlideRecord): boolean;
+  isAgentFor(queue: GlideRecord<any>): boolean;
   /**
    * Find out whether the queue is in schedule.
    */

--- a/server/sn_nlp_sentiment/sn_nlp_sentiment_SNAPISentimentAnalyser.d.ts
+++ b/server/sn_nlp_sentiment/sn_nlp_sentiment_SNAPISentimentAnalyser.d.ts
@@ -1,7 +1,7 @@
 import { GlideRecord } from '../GlideRecord';
 declare class sn_nlp_sentiment_SNAPISentimentAnalyser {
   constructor();
-  constructor(configGR: GlideRecord);
+  constructor(configGR: GlideRecord<any>);
   /**
    * Performs sentiment analysis on the specified text.
    * @param inputText Text on which sentiment analysis should be performed.
@@ -31,10 +31,10 @@ declare class sn_nlp_sentiment_SNAPISentimentAnalyser {
    * Returns the GlideRecord of the specified connector configuration.
    * @param connectorName Name of the connector configuration.
    */
-  getConnectorByName(connectorName: string): GlideRecord;
+  getConnectorByName(connectorName: string): GlideRecord<any>;
   /**
    * Returns the GlideRecord of the default connector configuration.
    */
-  getDefaultConnector(): GlideRecord;
+  getDefaultConnector(): GlideRecord<any>;
 }
 export { sn_nlp_sentiment_SNAPISentimentAnalyser };

--- a/server/sn_notification/sn_notification_SNAPIMessaging.d.ts
+++ b/server/sn_notification/sn_notification_SNAPIMessaging.d.ts
@@ -15,10 +15,10 @@ declare class sn_notification_SNAPIMessaging {
    * Messaging Contents record does not use a target table, set the value to null.
    */
   send(
-    messagingApplication: GlideRecord,
+    messagingApplication: GlideRecord<any>,
     recipient: string,
-    messagingContent: GlideRecord,
-    target: GlideRecord
+    messagingContent: GlideRecord<any>,
+    target: GlideRecord<any>
   ): void;
 }
 export { sn_notification_SNAPIMessaging };

--- a/server/sn_notify/sn_notify_SNAPINotify.d.ts
+++ b/server/sn_notify/sn_notify_SNAPINotify.d.ts
@@ -23,23 +23,23 @@ declare class sn_notify_SNAPINotify {
   call(
     notifyPhoneNumber: string,
     toPhoneNumber: string,
-    conferenceCall?: GlideRecord,
+    conferenceCall?: GlideRecord<any>,
     userSysId?: string,
     groupSysId?: string,
-    sourceRecord?: GlideRecord
+    sourceRecord?: GlideRecord<any>
   ): void;
   /**
    * Creates a new conference call GlideRecord.
    * @param sourceRecord Optional. Record that initiated the request to create the conference call. Used
    * to populate the source and table fields on notify_conference_call record.
    */
-  conferenceCall(sourceRecord?: GlideRecord): GlideRecord;
+  conferenceCall(sourceRecord?: GlideRecord<any>): GlideRecord<any>;
   /**
    * Resumes a call after it was put in a queue (on hold).
    * @param callRecord GlideRecord object on the Notify Call [notify_call] table with the held call
    * you want to resume.
    */
-  dequeueCall(callRecord: GlideRecord): void;
+  dequeueCall(callRecord: GlideRecord<any>): void;
   /**
    * Forwards the specified call to a different call recipient.
    * @param call Notify call record or the telephony provider call ID, of the call to be
@@ -48,7 +48,7 @@ declare class sn_notify_SNAPINotify {
    * which to forward the call.
    * @param dtmf Dual Tone - Multi Frequency (DTMF) code to send upon call connection.
    */
-  forwardCall(call: GlideRecord, destination: GlideRecord, dtmf: string): void;
+  forwardCall(call: GlideRecord<any>, destination: GlideRecord<any>, dtmf: string): void;
   /**
    * Returns a list of client sessions that are available to receive calls.
    * @param notifyNumber Valid Notify phone number.
@@ -68,7 +68,7 @@ declare class sn_notify_SNAPINotify {
    * @param record GlideRecord to use to identify the Notify client, such as a group record or a
    * user record.
    */
-  getTokens(record: GlideRecord): string;
+  getTokens(record: GlideRecord<any>): string;
   /**
    * Returns the maximum amount of time that a client session stays active for a specified
    * telephony driver before automatically timing out.
@@ -94,7 +94,7 @@ declare class sn_notify_SNAPINotify {
    * @param participant GlideRecord object containing the Notify Participant [notify_participant]
    * record of the caller to remove from the conference call.
    */
-  kick(participant: GlideRecord): void;
+  kick(participant: GlideRecord<any>): void;
   /**
    * Performs one or more activities on an active Notify phone call.
    * @param callRecord Notify Call [notify_call] record of the call for which to apply the
@@ -102,19 +102,19 @@ declare class sn_notify_SNAPINotify {
    * @param notifyAction NotifyAction object describing one or more activities to perform on the
    * call.
    */
-  modifyCall(callRecord: GlideRecord, notifyAction: any): void;
+  modifyCall(callRecord: GlideRecord<any>, notifyAction: any): void;
   /**
    * Mutes the specified conference call participant.
    * @param participantRecord GlideRecord from the notify_participant table for the participant to
    * mute.
    */
-  mute(participantRecord: GlideRecord): void;
+  mute(participantRecord: GlideRecord<any>): void;
   /**
    * Puts the specified call into a queue (on hold).
    * @param callRecord GlideRecord object of the Notify Call  record (notify_call table) to put on
    * hold.
    */
-  queueCall(callRecord: GlideRecord): void;
+  queueCall(callRecord: GlideRecord<any>): void;
   /**
    * Sends a specified SMS message to the specified list of Notify clients (phone
    * numbers).
@@ -128,7 +128,7 @@ declare class sn_notify_SNAPINotify {
     notifyPhoneNumber: NotifyPhoneNumber,
     toPhoneNumbers: string,
     messageBody: string,
-    source: GlideRecord
+    source: GlideRecord<any>
   ): string;
   /**
    * Sends an SMS text message to an E.164-compliant phone number.
@@ -141,13 +141,13 @@ declare class sn_notify_SNAPINotify {
     notifyPhoneNumber: NotifyPhoneNumber,
     toPhoneNumber: string,
     messageBody: string,
-    source: GlideRecord
+    source: GlideRecord<any>
   ): string;
   /**
    * Unmutes the specified conference call participant.
    * @param participantRecord GlideRecord from the notify_participant table for the participant to
    * unmute.
    */
-  unmute(participantRecord: GlideRecord): void;
+  unmute(participantRecord: GlideRecord<any>): void;
 }
 export { sn_notify_SNAPINotify };

--- a/server/sn_sc/sn_sc_SNAPICartJS.d.ts
+++ b/server/sn_sc/sn_sc_SNAPICartJS.d.ts
@@ -54,7 +54,7 @@ declare class sn_sc_SNAPICartJS {
    * Returns the GlideRecord for the cart item (sc_cart_item) in the current
    * cart.
    */
-  getCartItems(): GlideRecord;
+  getCartItems(): GlideRecord<any>;
   /**
    * Gets the delivery address for the current cart.
    */

--- a/server/sn_sc/sn_sc_SNAPICatalogJS.d.ts
+++ b/server/sn_sc/sn_sc_SNAPICatalogJS.d.ts
@@ -40,7 +40,7 @@ declare class sn_sc_SNAPICatalogJS {
   /**
    * Returns the catalog gliderecord.
    */
-  getGr(): GlideRecord;
+  getGr(): GlideRecord<any>;
   /**
    * Returns the catalog header icon.
    */

--- a/server/sn_sc/sn_sc_SNAPICatalogSearch.d.ts
+++ b/server/sn_sc/sn_sc_SNAPICatalogSearch.d.ts
@@ -16,6 +16,6 @@ declare class sn_sc_SNAPICatalogSearch {
     term: string,
     mobile: boolean,
     depthSearch: boolean
-  ): GlideRecord;
+  ): GlideRecord<any>;
 }
 export { sn_sc_SNAPICatalogSearch };

--- a/util/index.d.ts
+++ b/util/index.d.ts
@@ -1,9 +1,7 @@
 import { GlideRecord, GlideElement, sn_ws } from '../server';
 
-export type TypedGR<T> = T & GlideRecord;
-
 declare class ReferenceGlideElement<T> extends GlideElement {
-  getRefRecord(): TypedGR<T>;
+  getRefRecord(): GlideRecord<T>;
 }
 
 declare class TypedRequestBody<T> extends sn_ws.RESTAPIRequestBody {
@@ -14,4 +12,48 @@ declare class TypedRESTAPIRequest<T> extends sn_ws.RESTAPIRequest {
   body: TypedRequestBody<T>;
 }
 
-export { ReferenceGlideElement, TypedRESTAPIRequest };
+/**
+ * Operators available for filters and queries.
+ * https://docs.servicenow.com/bundle/newyork-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html
+ */
+type QueryOperator =
+  | 'STARTSWITH'
+  | 'ENDSWITH'
+  | '%'
+  | 'LIKE'
+  | '*'
+  | 'NOTLIKE'
+  | '!*'
+  | '='
+  | '!='
+  | 'ISEMPTY'
+  | 'ISNOTEMPTY'
+  | 'ANYTHING'
+  | 'EMPTYSTRING'
+  | '<='
+  | '<'
+  | '>='
+  | '>'
+  | 'BETWEEN'
+  | 'SAMEAS'
+  | 'NSAMEAS'
+  | 'DYNAMIC'
+  | 'ONToday'
+  | 'NOTONToday'
+  | 'DATEPART'
+  | 'RELATIVEGE'
+  | 'RELATIVELE'
+  | 'RELATIVEGT'
+  | 'RELATIVELT'
+  | 'RELATIVEEE'
+  | 'MORETHAN'
+  | 'LESSTHAN'
+  | 'GT_FIELD'
+  | 'LT_FIELD'
+  | 'GT_OR_EQUALS_FIELD'
+  | 'LT_OR_EQUALS_FIELD'
+  | 'VALCHANGES'
+  | 'CHANGESFROM'
+  | 'CHANGESTO';
+
+export { ReferenceGlideElement, TypedRESTAPIRequest, QueryOperator };


### PR DESCRIPTION
Found a way to get the generic features of @knikolov-nuvolo 's PR without having to do any typecasting with `as`. All generic classes that consumed `GlideRecord` were converted to take `GlideRecord<any>`