### PR TITLE
Make subtract(start,end) static for GlideDate/Time

### DIFF
--- a/server/GlideDate.d.ts
+++ b/server/GlideDate.d.ts
@@ -1,3 +1,11 @@
 import { SNAPIGlideDate } from "./SNAPIGlideDate";
-declare class GlideDate extends SNAPIGlideDate {}
+import { GlideDuration } from './GlideDuration';
+declare class GlideDate extends SNAPIGlideDate {
+    /**
+   * Gets the duration difference between two GlideDate values.
+   * @param start The start value.
+   * @param end The end value.
+   */
+  static subtract(start: GlideDate, end: GlideDate): GlideDuration;
+}
 export { GlideDate };

--- a/server/GlideDateTime.d.ts
+++ b/server/GlideDateTime.d.ts
@@ -1,3 +1,12 @@
 import { SNAPIGlideDateTime } from "./SNAPIGlideDateTime";
-declare class GlideDateTime extends SNAPIGlideDateTime {}
+import { GlideDuration } from './GlideDuration';
+declare class GlideDateTime extends SNAPIGlideDateTime {
+    /**
+   * Gets the duration difference between two GlideDateTime values.
+   * @param start The start value.
+   * @param end The end value.
+   */
+    static subtract(start: GlideDateTime, end: GlideDateTime): GlideDuration;
+
+}
 export { GlideDateTime };


### PR DESCRIPTION
Added subtract as a static method to GlideDate and GlideDateTime.  It seems the other GlideDateTime subtract methods are not static.