### PR TITLE
#18: addJoinQuery argument is strongly typed

### DIFF
--- a/server/GlideQueryCondition.d.ts
+++ b/server/GlideQueryCondition.d.ts
@@ -1,5 +1,6 @@
 import { SNAPIGlideQueryCondition } from './SNAPIGlideQueryCondition';
-declare class GlideQueryCondition extends SNAPIGlideQueryCondition {
+import { QueryOperator, FieldType } from '../util';
+declare class GlideQueryCondition<T> extends SNAPIGlideQueryCondition {
   /**
    * Adds an AND condition to the current condition.
    * @param name The name of a field.
@@ -7,12 +8,12 @@ declare class GlideQueryCondition extends SNAPIGlideQueryCondition {
    * condition uses an equals operator.
    * @param value The value to query on.
    */
-  addCondition(name: string, value: any): GlideQueryCondition;
+  addCondition(name: FieldType<T>, value: any): GlideQueryCondition<T>;
   addCondition(
-    name: string,
-    oper: string | undefined,
-    value: any
-  ): GlideQueryCondition;
+    name: FieldType<T>,
+    oper: QueryOperator | undefined,
+    value: any,
+  ): GlideQueryCondition<T>;
   /**
    * Appends a 2-or-3 parameter OR condition to an existing GlideQueryCondition.
    * @param name Field name
@@ -53,11 +54,11 @@ declare class GlideQueryCondition extends SNAPIGlideQueryCondition {
    * contain a minimum of two elements. Single element arrays are not
    * supported.
    */
-  addOrCondition(name: string, value: any): GlideQueryCondition;
+  addOrCondition(name: FieldType<T>, value: any): GlideQueryCondition<T>;
   addOrCondition(
-    name: string,
-    oper: string | undefined,
-    value: any
-  ): GlideQueryCondition;
+    name: FieldType<T>,
+    oper: QueryOperator | undefined,
+    value: any,
+  ): GlideQueryCondition<T>;
 }
 export { GlideQueryCondition };

--- a/server/GlideRecord.d.ts
+++ b/server/GlideRecord.d.ts
@@ -1,9 +1,12 @@
 import { SNAPIGlideRecord } from './SNAPIGlideRecord';
 import { GlideQueryCondition } from './GlideQueryCondition';
 import { GlideElement } from './GlideElement';
-import { QueryOperator } from '../util';
-type FieldType<T> = Extract<keyof T, string>;
+import { QueryOperator, FieldType } from '../util';
 declare class GlideRecordBase<T> extends SNAPIGlideRecord {
+  /**
+   * Adds a filter to return active records.
+   */
+  addActiveQuery(): GlideQueryCondition<T>;
   /**
    * Adds a filter to return records based on a relationship in a related table.
    * @param joinTable Table name
@@ -14,14 +17,14 @@ declare class GlideRecordBase<T> extends SNAPIGlideRecord {
     joinTable: string,
     primaryField?: FieldType<T>,
     joinTableField?: FieldType<TJoinTable>,
-  ): GlideQueryCondition;
+  ): GlideQueryCondition<TJoinTable>;
 
   /**
    * A filter that specifies records where the value of the field passed in the parameter is
    * not null.
    * @param fieldName Name of the field to check.
    */
-  addNotNullQuery(fieldName: FieldType<T>): GlideQueryCondition;
+  addNotNullQuery(fieldName: FieldType<T>): GlideQueryCondition<T>;
 
   /**
    * Provides the ability to build a request, which when executed, returns the rows from the
@@ -29,13 +32,13 @@ declare class GlideRecordBase<T> extends SNAPIGlideRecord {
    * @param fieldName Table field name.
    * @param value Value on which to query (not case-sensitive).
    */
-  addQuery(): GlideQueryCondition;
-  addQuery(fieldName: FieldType<T>, value: any): GlideQueryCondition;
+  addQuery(): GlideQueryCondition<T>;
+  addQuery(fieldName: FieldType<T>, value: any): GlideQueryCondition<T>;
   addQuery(
     name: FieldType<T>,
     operator: QueryOperator,
     value: any,
-  ): GlideQueryCondition;
+  ): GlideQueryCondition<T>;
   /**
    * Returns the specified record in an instantiated GlideRecord object.
    * @param sys_id sys_id of the record to get.

--- a/server/GlideRecord.d.ts
+++ b/server/GlideRecord.d.ts
@@ -10,10 +10,10 @@ declare class GlideRecordBase<T> extends SNAPIGlideRecord {
    * @param primaryField (Optional) If other than sys_id, the primary field
    * @param joinTableField (Optional) If other than sys_id, the field that joins the tables.
    */
-  addJoinQuery(
+  addJoinQuery<TJoinTable>(
     joinTable: string,
     primaryField?: FieldType<T>,
-    joinTableField?: any,
+    joinTableField?: FieldType<TJoinTable>,
   ): GlideQueryCondition;
 
   /**

--- a/server/SNAPIGlideAggregate.d.ts
+++ b/server/SNAPIGlideAggregate.d.ts
@@ -17,19 +17,23 @@ declare class SNAPIGlideAggregate {
    * Adds a not null query to the aggregate.
    * @param fieldname The name of the field.
    */
-  addNotNullQuery(fieldname: string): GlideQueryCondition;
+  addNotNullQuery(fieldname: string): GlideQueryCondition<any>;
   /**
    * Adds a null query to the aggregate.
    * @param fieldName The name of the field.
    */
-  addNullQuery(fieldName: string): GlideQueryCondition;
+  addNullQuery(fieldName: string): GlideQueryCondition<any>;
   /**
    * Adds a query to the aggregate.
    * @param name The query to add.
    * @param operator The operator for the query.
    * @param value The list of values to include in the query.
    */
-  addQuery(name: string, operator: string, value: string): GlideQueryCondition;
+  addQuery(
+    name: string,
+    operator: string,
+    value: string,
+  ): GlideQueryCondition<any>;
   /**
    * Adds a trend for a field.
    * @param fieldName The name of the field for which trending should occur.

--- a/server/SNAPIGlideQueryCondition.d.ts
+++ b/server/SNAPIGlideQueryCondition.d.ts
@@ -10,8 +10,8 @@ declare class SNAPIGlideQueryCondition {
   addCondition(
     name: string,
     oper: string | undefined,
-    value: any
-  ): GlideQueryCondition;
+    value: any,
+  ): GlideQueryCondition<any>;
   /**
    * Appends a 2-or-3 parameter OR condition to an existing GlideQueryCondition.
    * @param name Field name
@@ -55,7 +55,7 @@ declare class SNAPIGlideQueryCondition {
   addOrCondition(
     name: string,
     oper: string | undefined,
-    value: any
-  ): GlideQueryCondition;
+    value: any,
+  ): GlideQueryCondition<any>;
 }
 export { SNAPIGlideQueryCondition };

--- a/server/SNAPIGlideRecord.d.ts
+++ b/server/SNAPIGlideRecord.d.ts
@@ -5,7 +5,7 @@ declare class SNAPIGlideRecord {
   /**
    * Adds a filter to return active records.
    */
-  addActiveQuery(): GlideQueryCondition;
+  addActiveQuery(): GlideQueryCondition<any>;
   /**
    * Adds an encoded query to other queries that may have been set.
    * @param query An encoded query
@@ -27,27 +27,27 @@ declare class SNAPIGlideRecord {
   addJoinQuery(
     joinTable: string,
     primaryField?: any,
-    joinTableField?: any
-  ): GlideQueryCondition;
+    joinTableField?: any,
+  ): GlideQueryCondition<any>;
   /**
    * A filter that specifies records where the value of the field passed in the parameter is
    * not null.
    * @param fieldName Name of the field to check.
    */
-  addNotNullQuery(fieldName: string): GlideQueryCondition;
+  addNotNullQuery(fieldName: string): GlideQueryCondition<any>;
   /**
    * Adds a filter to return records where the value of the specified field is
    * null.
    * @param fieldName Name of the field to check.
    */
-  addNullQuery(fieldName: string): GlideQueryCondition;
+  addNullQuery(fieldName: string): GlideQueryCondition<any>;
   /**
    * Provides the ability to build a request, which when executed, returns the rows from the
    * specified table, that match the request.
    * @param name Table field name.
    * @param value Value on which to query (not case-sensitive).
    */
-  addQuery(name: string, value: any): GlideQueryCondition;
+  addQuery(name: string, value: any): GlideQueryCondition<any>;
   /**
    * Provides the ability to build a request, which when executed, returns the rows from the
    * specified table, that match the request.
@@ -91,12 +91,16 @@ declare class SNAPIGlideRecord {
    *
    * @param value Value on which to query (not case-sensitive).
    */
-  addQuery(name: string, operator: string, value: any): GlideQueryCondition;
+  addQuery(
+    name: string,
+    operator: string,
+    value: any,
+  ): GlideQueryCondition<any>;
   /**
    * Provides the ability to build a request, which when executed, returns the rows from the
    * specified table, that match the request.
    */
-  addQuery(): GlideQueryCondition;
+  addQuery(): GlideQueryCondition<any>;
   /**
    * Determines if the Access Control Rules, which include the user's roles, permit
    * inserting new records in this table.

--- a/util/index.d.ts
+++ b/util/index.d.ts
@@ -12,6 +12,8 @@ declare class TypedRESTAPIRequest<T> extends sn_ws.RESTAPIRequest {
   body: TypedRequestBody<T>;
 }
 
+type FieldType<T> = Extract<keyof T, string>;
+
 /**
  * Operators available for filters and queries.
  * https://docs.servicenow.com/bundle/newyork-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html
@@ -56,4 +58,4 @@ type QueryOperator =
   | 'CHANGESFROM'
   | 'CHANGESTO';
 
-export { ReferenceGlideElement, TypedRESTAPIRequest, QueryOperator };
+export { ReferenceGlideElement, TypedRESTAPIRequest, FieldType, QueryOperator };


### PR DESCRIPTION
#18: GlideRecord.addJoinQuery() should require correct field name for the second table 

- `GlideRecord.addJoinQuery()` is made generic. When used a type for the second table must be given. Validation and intellisense for arguments is  added.

![image](https://user-images.githubusercontent.com/56968282/75548714-9a332b80-5a36-11ea-9d0b-55d4507d9363.png)

- `GlideQueryCondition` is also made generic. All methods in `GlideRecord` that uses it use the appropriate type, all other methods use `any`. Provides validation and intellisense for method arguments in the class.

![image](https://user-images.githubusercontent.com/56968282/75560970-dbcfd080-5a4e-11ea-83d2-748b9cc0c945.png)

