### PR TITLE
Limit query operators to docs

### DIFF
--- a/util/index.d.ts
+++ b/util/index.d.ts
@@ -16,46 +16,21 @@ type FieldType<T> = Extract<keyof T, string>;
 
 /**
  * Operators available for filters and queries.
- * https://docs.servicenow.com/bundle/newyork-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html
+ * https://developer.servicenow.com/dev.do#!/reference/api/orlando/server/r_ScopedGlideRecordAddQuery_String_String_Object
  */
 type QueryOperator =
-  | 'STARTSWITH'
-  | 'ENDSWITH'
-  | '%'
-  | 'LIKE'
-  | '*'
-  | 'NOTLIKE'
-  | '!*'
   | '='
   | '!='
-  | 'ISEMPTY'
-  | 'ISNOTEMPTY'
-  | 'ANYTHING'
-  | 'EMPTYSTRING'
-  | '<='
-  | '<'
-  | '>='
   | '>'
-  | 'BETWEEN'
-  | 'SAMEAS'
-  | 'NSAMEAS'
-  | 'DYNAMIC'
-  | 'ONToday'
-  | 'NOTONToday'
-  | 'DATEPART'
-  | 'RELATIVEGE'
-  | 'RELATIVELE'
-  | 'RELATIVEGT'
-  | 'RELATIVELT'
-  | 'RELATIVEEE'
-  | 'MORETHAN'
-  | 'LESSTHAN'
-  | 'GT_FIELD'
-  | 'LT_FIELD'
-  | 'GT_OR_EQUALS_FIELD'
-  | 'LT_OR_EQUALS_FIELD'
-  | 'VALCHANGES'
-  | 'CHANGESFROM'
-  | 'CHANGESTO';
+  | '>='
+  | '<'
+  | '<='
+  | 'IN'
+  | 'NOT IN'
+  | 'STARTSWITCH'
+  | 'ENDSWITH'
+  | 'CONTAINS'
+  | 'DOES NOT CONTAIN'
+  | 'INSTANCEOF';
 
 export { ReferenceGlideElement, TypedRESTAPIRequest, FieldType, QueryOperator };


### PR DESCRIPTION
The list of query operators used for GlideRecord queries was pulled from the list of encoded query operators. Some of these can be a footgun for using `addQuery` due to the way they have to be used with a blank string. This PR limits them to the recommended operators for `addQuery` and the rest can be used in encoded queries for clarity. In addition, it adds some missing operators necessary for `addQuery`