### PR TITLE
GlideRecord - getDisplayName - Added function

### DIFF
--- a/server/SNAPIGlideRecord.d.ts
+++ b/server/SNAPIGlideRecord.d.ts
@@ -156,6 +156,10 @@ declare class SNAPIGlideRecord {
    */
   getClassDisplayValue(): string;
   /**
+   * Returns the table's display field.
+   */
+  getDisplayName(): string;
+  /**
    * Retrieves the display value for the current record.
    */
   getDisplayValue(): string;


### PR DESCRIPTION
GlideRecord was missing the function getDisplayName to return the display field for the table.

For instance on the task table gr.getDisplayName() will return _number_ by default.