### PR TITLE
Updating .getED to return the correct type (void => GlideElementDescriptor)

### DIFF
--- a/server/GlideElement.d.ts
+++ b/server/GlideElement.d.ts
@@ -1,4 +1,5 @@
 import { SNAPIGlideElement } from './SNAPIGlideElement';
+import { GlideElementDescriptor } from './GlideElementDescriptor';
 declare class GlideElement extends SNAPIGlideElement {
   // Methods to access currency fields
   // TODO:
@@ -108,5 +109,10 @@ declare class GlideElement extends SNAPIGlideElement {
    * Example: "USD"
    */
   getReferenceCurrencyCode(): string;
+
+  /**
+   * Returns the field's element descriptor.
+   */
+  getED(): GlideElementDescriptor;
 }
 export { GlideElement };

--- a/server/SNAPIGlideElement.d.ts
+++ b/server/SNAPIGlideElement.d.ts
@@ -1,4 +1,5 @@
 import { GlideRecord } from './GlideRecord';
+import { GlideElementDescriptor } from './GlideElementDescriptor';
 declare class SNAPIGlideElement {
   /**
    * Determines if the user's role permits the creation of new records in this
@@ -71,7 +72,7 @@ declare class SNAPIGlideElement {
   /**
    * Returns the field's element descriptor.
    */
-  getED(): void;
+  getED(): GlideElementDescriptor;
   /**
    * Returns the phone number in international format.
    */

--- a/server/SNAPIGlideElement.d.ts
+++ b/server/SNAPIGlideElement.d.ts
@@ -1,5 +1,4 @@
 import { GlideRecord } from './GlideRecord';
-import { GlideElementDescriptor } from './GlideElementDescriptor';
 declare class SNAPIGlideElement {
   /**
    * Determines if the user's role permits the creation of new records in this
@@ -72,7 +71,7 @@ declare class SNAPIGlideElement {
   /**
    * Returns the field's element descriptor.
    */
-  getED(): GlideElementDescriptor;
+  getED(): void;
   /**
    * Returns the phone number in international format.
    */


### PR DESCRIPTION
Updating the getED response type on GlideElement to return GlideElementDescriptor. Below is documentation to prove getED returns GlideElementDescriptor on the GlideElement in addition to GlideRecord.

[Documentation](https://developer.servicenow.com/dev.do#!/reference/api/orlando/server/no-namespace/c_GlideElementScopedAPI#r_ScopedGlideElementGetED)

Note: GlideRecord's getED is already correct
